### PR TITLE
Support classname append + update getFieldErrors type

### DIFF
--- a/demo-app/app/routes/index.tsx
+++ b/demo-app/app/routes/index.tsx
@@ -72,20 +72,20 @@ export const action: ActionFunction = async ({ request }) => {
   return redirect("/");
 };
 
+// This is a more complex example of skipping <Field/> in favor of manual
+// DOM construction
 function EmailAddress() {
   let { info, getInputAttrs, getLabelAttrs, getErrorsAttrs } =
-    useValidatedInput({
-      name: "emailAddress",
-    });
+    useValidatedInput({ name: "emailAddress" });
   return (
     <div>
       <label {...getLabelAttrs()}>Email Address*</label>
       <br />
-      <input {...getInputAttrs()} />
+      <input {...getInputAttrs({})} />
       {info.touched && info.errorMessages ? (
         <ul {...getErrorsAttrs()}>
-          {Object.values(info.errorMessages).map((msg) => (
-            <li key={msg}>🆘 {msg}</li>
+          {Object.entries(info.errorMessages).map(([validation, msg]) => (
+            <li key={validation}>🆘 {msg}</li>
           ))}
         </ul>
       ) : null}
@@ -159,7 +159,7 @@ export default function Index() {
           margin: 0;
           padding: 0;
         }
-        
+
         .rvs-errors {
           color: red;
           list-style: none;
@@ -241,7 +241,7 @@ export default function Index() {
               </span>
             </p>
             <div className="demo-input">
-              <Field name="emailAddress" label="Email Address" />
+              <EmailAddress />
             </div>
           </div>
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -210,6 +210,15 @@ const callAll =
   (...fns: (Function | undefined)[]) =>
   (...args: any[]) =>
     fns.forEach((fn) => fn?.(...args));
+const composeClassNames = (classes: Array<string | undefined>) =>
+  classes.filter((v) => v).join(" ");
+const omit = (
+  obj: Record<string, any>,
+  ...keys: string[]
+): Record<string, any> =>
+  Object.entries(obj)
+    .filter(([k]) => !keys.includes(k))
+    .reduce((acc, [k, v]) => Object.assign(acc, { [k]: v }), {});
 
 function getBaseValidityState(): ExtendedValidityState {
   return {
@@ -431,16 +440,15 @@ export function useValidatedInput(opts: {
     go().catch((e) => console.error("Error in validateInput useEffect", e));
   }, [dirty, touched, value, formValidations, name, serverFormInfo]);
 
-  function getClasses(type: "label" | "input") {
-    return [
+  function getClasses(type: "label" | "input", className?: string) {
+    return composeClassNames([
       `rvs-${type}`,
       showErrors ? `rvs-${type}--invalid` : "",
       validationState === "validating" ? `rvs-${type}--validating` : "",
       touched ? `rvs-${type}--touched` : "",
       dirty ? `rvs-${type}--dirty` : "",
-    ]
-      .filter((v) => v)
-      .join(" ");
+      className,
+    ]);
   }
 
   // Provide the caller a prop getter to be spread onto the <input>
@@ -459,7 +467,7 @@ export function useValidatedInput(opts: {
       ref: inputRef,
       name,
       id: getInputId(name),
-      className: getClasses("input"),
+      className: getClasses("input", attrs.className),
       defaultValue: serverFormInfo?.submittedFormData?.lastName,
       onChange: callAll(onChange, (e: React.ChangeEvent<HTMLInputElement>) => {
         setDirty(true);
@@ -472,7 +480,7 @@ export function useValidatedInput(opts: {
           }
         : {}),
       ...validationAttrs,
-      ...attrs,
+      ...omit(attrs, "className"),
     };
 
     return inputAttrs;
@@ -483,10 +491,10 @@ export function useValidatedInput(opts: {
     ...attrs
   }: React.ComponentPropsWithoutRef<"label"> = {}): React.ComponentPropsWithoutRef<"label"> {
     return {
-      className: getClasses("label"),
+      className: getClasses("label", attrs.className),
       htmlFor: getInputId(name),
       defaultValue: serverFormInfo?.submittedFormData?.radioThing,
-      ...attrs,
+      ...omit(attrs, "className"),
     };
   }
 
@@ -496,10 +504,10 @@ export function useValidatedInput(opts: {
     ...attrs
   }: React.ComponentPropsWithoutRef<"ul"> = {}): React.ComponentPropsWithoutRef<"ul"> {
     return {
-      className: "rvs-errors",
+      className: composeClassNames(["rvs-errors", attrs.className]),
       id: getErrorsId(name),
       ...(showErrors ? { role: "alert" } : {}),
-      ...attrs,
+      ...omit(attrs, "className"),
     };
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -447,7 +447,7 @@ export function useValidatedInput(opts: {
   function getInputAttrs({
     onChange,
     ...attrs
-  }: React.ComponentPropsWithoutRef<"input"> = {}) {
+  }: React.ComponentPropsWithoutRef<"input"> = {}): React.ComponentPropsWithoutRef<"input"> {
     let validationAttrs = Object.entries(formValidations?.[name] || {}).reduce(
       (acc, [attr, value]) =>
         attr in builtInValidations
@@ -494,7 +494,7 @@ export function useValidatedInput(opts: {
   // their rendered validation errors
   function getErrorsAttrs({
     ...attrs
-  }: Record<string, string>): Record<string, string> {
+  }: React.ComponentPropsWithoutRef<"ul"> = {}): React.ComponentPropsWithoutRef<"ul"> {
     return {
       className: "rvs-errors",
       id: getErrorsId(name),


### PR DESCRIPTION
* Update `getErrorsAttrs` param to be optional (closes #5)
* Update `getErrorsAttrs` parameter type to assume you're using a `<ul>` element and type incoming attributes accordingly (closes #6)
* Passing a `className` in the parameters to `getInputAttrs`/`getLabelAttrs`/`getErrorsAttrs` should append to built-in classes, while adding a `className` attribute _after_ the spread will replace (closes #2) 
  * append: `<input {...getInputAttrs({ className: "foo bar" })} />`
  * replace: `<input {...getInputAttrs()} className="foo bar" />`