### PR TITLE
fix: Check for `event.preventDefault()` before setting state

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -213,10 +213,6 @@ function invariant(value: any, message?: string) {
 const getInputId = (name: string, reactId: string) => `${name}--${reactId}`;
 const getErrorsId = (name: string, reactId: string) =>
   `${name}-errors--${reactId}`;
-const callAll =
-  (...fns: (Function | undefined)[]) =>
-  (...args: any[]) =>
-    fns.forEach((fn) => fn?.(...args));
 const composeClassNames = (classes: Array<string | undefined>) =>
   classes.filter((v) => v).join(" ");
 const omit = (
@@ -510,10 +506,13 @@ export function useValidatedInput<T extends FormValidations>(
       id: getInputId(name, id),
       className: getClasses("input", attrs.className),
       defaultValue: serverFormInfo?.submittedFormData?.lastName,
-      onChange: callAll(onChange, (e: React.ChangeEvent<HTMLInputElement>) => {
-        setDirty(true);
-        setValue(e.target.value);
-      }),
+      onChange: (event: React.ChangeEvent<HTMLInputElement>) => {
+        onChange && onChange(event);
+        if (!event.defaultPrevented) {
+          setDirty(true);
+          setValue(event.target.value);
+        }
+      },
       ...(showErrors
         ? {
             "aria-invalid": true,


### PR DESCRIPTION
If a user prevents a form input's default behavior, the `onChange` in `getInputAttrs` shouldn't set state internally. To fix this I call the user's handler first, check for `event.defaultPrevented` and then continue with the internal event handler.