### PR TITLE
Slim build and remove UMD bundle

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,4 @@
+# Browsers that we support
+
+defaults and supports es6-module
+maintained node versions

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Semantically correct and accessible `<form>` markup is verbose. Any convenient f
 > yarn add remix-validity-state
 ```
 
+> **Info**
+>
+> This library is bundled for modern browsers (see `.browserslistrc`). If you need to support older browsers you may need to configure your build process accordingly.
+
 ## Usage
 
 ### Demo App

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.6.0",
   "author": "matt@brophy.org",
   "description": "A Remix form validation library extending on the HTML ValidityState API",
-  "browser": "./dist/remix-validity-state.umd.js",
   "main": "./dist/remix-validity-state.cjs.js",
   "module": "./dist/remix-validity-state.esm.js",
   "types": "./dist/index.d.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,13 +29,6 @@ export default function rollup() {
       input: `${SOURCE_DIR}/index.tsx`,
       output: [
         {
-          file: getOutputFile(packageJson.browser),
-          format: "umd",
-          name: "RemixValidityState",
-          globals: { react: "React" },
-          ...output,
-        },
-        {
           file: getOutputFile(packageJson.main),
           format: "cjs",
           ...output,
@@ -46,13 +39,13 @@ export default function rollup() {
           ...output,
         },
       ],
-      external: ["react"],
+      external: ["react", "@babel/runtime/helpers/extends"],
       plugins: [
         babel({
           exclude: /node_modules/,
           babelHelpers: "runtime",
           presets: [
-            ["@babel/preset-env", { loose: true }],
+            ["@babel/preset-env", { loose: true, debug: true }],
             "@babel/preset-react",
             "@babel/preset-typescript",
           ],


### PR DESCRIPTION
Trim the bundle by adding `.browserslistrc` with a fairly modern baseline.  Also removed the UMD build since we'll assume bundlers are being used with this library.