### PR TITLE
Change structure for form definition

### DIFF
--- a/demo-app/app/routes/index.tsx
+++ b/demo-app/app/routes/index.tsx
@@ -2,7 +2,13 @@ import { Form, useActionData } from "@remix-run/react";
 import type { ActionFunction } from "@remix-run/server-runtime";
 import { json, redirect } from "@remix-run/server-runtime";
 import * as React from "react";
-import type { FormDefinition, ServerFormInfo } from "remix-validity-state";
+import type {
+  ErrorMessage,
+  FormDefinition,
+  InputDefinition,
+  InputInfo,
+  ServerFormInfo,
+} from "remix-validity-state";
 import {
   Field,
   FormContextProvider,
@@ -10,7 +16,19 @@ import {
   validateServerFormData,
 } from "remix-validity-state";
 
-let formDefinition: FormDefinition = {
+interface FormSchema {
+  inputs: {
+    firstName: InputDefinition;
+    middleInitial: InputDefinition;
+    lastName: InputDefinition;
+    emailAddress: InputDefinition;
+  };
+  errorMessages: {
+    tooShort: ErrorMessage;
+  };
+}
+
+let formDefinition: FormSchema = {
   inputs: {
     firstName: {
       validationAttrs: {
@@ -69,8 +87,6 @@ export const action: ActionFunction = async ({ request }) => {
   // descendant inputs.  Maybe we can do a pub/sub through context?
   const serverFormInfo = await validateServerFormData(formData, formDefinition);
 
-  // TODO: Type inference is broken here on serverformInfo.inputs.*?
-
   if (!serverFormInfo.valid) {
     return json<ActionData>({ serverFormInfo });
   }
@@ -100,8 +116,6 @@ function EmailAddress() {
 
 export default function Index() {
   let actionData = useActionData() as ActionData;
-
-  // TODO: Type inference is broken here on actionData.serverFormInfo.inputs.*?
 
   let formRef = React.useRef<HTMLFormElement>(null);
 

--- a/demo-app/app/routes/index.tsx
+++ b/demo-app/app/routes/index.tsx
@@ -4,9 +4,7 @@ import { json, redirect } from "@remix-run/server-runtime";
 import * as React from "react";
 import type {
   ErrorMessage,
-  FormDefinition,
   InputDefinition,
-  InputInfo,
   ServerFormInfo,
 } from "remix-validity-state";
 import {

--- a/demo-app/package-lock.json
+++ b/demo-app/package-lock.json
@@ -11,7 +11,7 @@
         "@remix-run/serve": "^1.7.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "remix-validity-state": "^0.5.0"
+        "remix-validity-state": "^0.6.0"
       },
       "devDependencies": {
         "@remix-run/dev": "^1.7.0",
@@ -10491,9 +10491,9 @@
       }
     },
     "node_modules/remix-validity-state": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/remix-validity-state/-/remix-validity-state-0.5.0.tgz",
-      "integrity": "sha512-j6HiwgTsuO+bsuXmxVBPkTTVUkodBiWgGztuufYT8NK6X1YkD/MLgzngPl9CstMn+fuHl1oc0cm0nx2AIh4RnQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/remix-validity-state/-/remix-validity-state-0.6.0.tgz",
+      "integrity": "sha512-DD8X76zgpdMG66oU2miodJO0LsNmpULKyU+ljcoYCoHDSzBr13tHEMPk91+RqT0THKXT+l9JOdt6mmJlBr0CKg==",
       "dependencies": {
         "@babel/runtime": "7.17.8"
       },
@@ -19498,9 +19498,9 @@
       }
     },
     "remix-validity-state": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/remix-validity-state/-/remix-validity-state-0.5.0.tgz",
-      "integrity": "sha512-j6HiwgTsuO+bsuXmxVBPkTTVUkodBiWgGztuufYT8NK6X1YkD/MLgzngPl9CstMn+fuHl1oc0cm0nx2AIh4RnQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/remix-validity-state/-/remix-validity-state-0.6.0.tgz",
+      "integrity": "sha512-DD8X76zgpdMG66oU2miodJO0LsNmpULKyU+ljcoYCoHDSzBr13tHEMPk91+RqT0THKXT+l9JOdt6mmJlBr0CKg==",
       "requires": {
         "@babel/runtime": "7.17.8"
       }

--- a/demo-app/package.json
+++ b/demo-app/package.json
@@ -12,7 +12,7 @@
     "@remix-run/serve": "^1.7.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "remix-validity-state": "^0.5.0"
+    "remix-validity-state": "^0.6.0"
   },
   "devDependencies": {
     "@remix-run/dev": "^1.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@babel/preset-typescript": "7.16.7",
         "@remix-run/eslint-config": "1.3.4",
         "@rollup/plugin-babel": "5.3.1",
+        "@rollup/plugin-typescript": "^11.0.0",
         "@types/react": "^18.0.19",
         "eslint": "8.12.0",
         "eslint-config-prettier": "8.5.0",
@@ -1969,6 +1970,60 @@
         }
       }
     },
+    "node_modules/@rollup/plugin-typescript": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.0.0.tgz",
+      "integrity": "sha512-goPyCWBiimk1iJgSTgsehFD5OOFHiAknrRJjqFCudcW8JtWiBlK284Xnn4flqMqg6YAjVG/EE+3aVzrL5qNSzQ==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.14.0||^3.0.0",
+        "tslib": "*",
+        "typescript": ">=3.7.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "tslib": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-typescript/node_modules/@rollup/pluginutils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-typescript/node_modules/@types/estree": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+      "dev": true
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
@@ -3559,6 +3614,12 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3972,9 +4033,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -4818,12 +4879,12 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.9.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -6664,6 +6725,35 @@
         "@rollup/pluginutils": "^3.1.0"
       }
     },
+    "@rollup/plugin-typescript": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.0.0.tgz",
+      "integrity": "sha512-goPyCWBiimk1iJgSTgsehFD5OOFHiAknrRJjqFCudcW8JtWiBlK284Xnn4flqMqg6YAjVG/EE+3aVzrL5qNSzQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^5.0.1",
+        "resolve": "^1.22.1"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+          "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "^1.0.0",
+            "estree-walker": "^2.0.2",
+            "picomatch": "^2.3.1"
+          }
+        },
+        "@types/estree": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+          "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+          "dev": true
+        }
+      }
+    },
     "@rollup/pluginutils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
@@ -7816,6 +7906,12 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true
     },
+    "estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -8122,9 +8218,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -8741,12 +8837,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
       "dev": true,
       "requires": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.9.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/brophdawg11/remix-validity-state#readme",
   "scripts": {
-    "build": "tsc -b && rollup -c ./rollup.config.js",
+    "build": "rollup -c ./rollup.config.js",
     "clean": "rm -rf dist/",
     "dev": "OUTPUT_DIR=demo-app/node_modules/remix-validity-state npm run build -- --watch",
     "lint": "eslint --ext .js,.ts,.tsx .",
@@ -47,6 +47,7 @@
     "@babel/preset-typescript": "7.16.7",
     "@remix-run/eslint-config": "1.3.4",
     "@rollup/plugin-babel": "5.3.1",
+    "@rollup/plugin-typescript": "^11.0.0",
     "@types/react": "^18.0.19",
     "eslint": "8.12.0",
     "eslint-config-prettier": "8.5.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "src/",
     "dist/"
   ],
-  "sideEffects": "false",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/brophdawg11/remix-validity-state.git"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
 import babel from "@rollup/plugin-babel";
+import typescript from "@rollup/plugin-typescript";
 
 import packageJson from "./package.json";
 
@@ -41,6 +42,7 @@ export default function rollup() {
       ],
       external: ["react", "@babel/runtime/helpers/extends"],
       plugins: [
+        typescript(),
         babel({
           exclude: /node_modules/,
           babelHelpers: "runtime",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -338,14 +338,18 @@ export async function validateServerFormData<T extends FormDefinition>(
     {}
   );
 
-  const inputs = {} as Record<KeyOf<T["inputs"]>, InputInfo>;
+  // Unsure if there's a better way to do this - but this complains since we
+  // haven't filled in the keys yet
+  // @ts-expect-error
+  const inputs: Record<KeyOf<T["inputs"]>, InputInfo> = {};
+
   let valid = true;
+  let entries = Object.entries(formDefinition.inputs) as Array<
+    [KeyOf<T["inputs"]>, InputDefinition]
+  >;
   await Promise.all(
-    Object.keys(formDefinition.inputs).map(async (name) => {
-      // TODO can we infer this?
-      let inputName = name as KeyOf<T["inputs"]>;
-      let inputDef = formDefinition.inputs[name];
-      const value = formData.get(name);
+    entries.map(async ([inputName, inputDef]) => {
+      const value = formData.get(inputName);
       if (typeof value === "string") {
         let validity = await validateInput(null, value, inputDef, formData);
         // Always assume inputs have been modified during SSR validation


### PR DESCRIPTION
### ⚠️ This is a breaking Change

Previously, we went with a very minimal API for defining your form validations (which are just attributes in the built-in cases):

```js
const formValidations = {
  firstName: {
    required: true,
    maxLength: 50,
  },
  lastName: {
    required: true,
    maxLength: 50,
  },
};
```

But as we scaled up functionality, this started to become a bit limiting:

1. Adding custom validations _directly alongside_ built-in attributes makes type restrictions harder, since you can't restrict the object keys to only those built-in HTML validation attributes.
2. There's no room for custom error messages, so they needed to go in a separate object.  Being able to colocate them with their specific validations would be nice.
3. Typings got really [nasty](https://github.com/brophdawg11/remix-validity-state/issues/21#issuecomment-1285552673) when looking to implement additional, seemingly simple, functionality

This PR moves to a new more-comprehensive API for defining your form information with 2 major changes:

1. Built-in validations are separated from custom validations
2. Error messages can be included at either the field level or the global level

A new form definition would looks look like:

```
import type { ErrorMessage, InputDefinition } from "remix-validity-state";

// Define your schema so we can properly infer types on things such as `serverFormData.inputs`
interface MyFormSchema {
  inputs: {
    username: InputDefinition;
    emailAddress: InputDefinition;
  };
  errorMessages: {
    tooShort: ErrorMessage;
  };
}

let formDefinition: FormSchema = {
  inputs: {
    username: {
      validationAttrs: {  // 👈 Built-in HTML validations
        required: true,
        minLength: 5,
        pattern: "^[a-zA-Z]+$",
      },
    },
    emailAddress: {
      validationAttrs: {
        type: "email",
        required: true,
      },
      customValidations: {  // 👈 Custom validations
        async uniqueEmail(value) {
          await new Promise((r) => setTimeout(r, 1000));
          return value !== "john@doe.com" && value !== "jane@doe.com";
        },
      },
      errorMessages: {  // 👈 Field-level error messages
        uniqueEmail(attrValue, name, value) {
          return `The email address "${value}" is already in use!`;
        },
      },
    },
  },
  errorMessages: {  // 👈 Global error messages
    tooShort: (attrValue) => `Field must be at least ${attrValue} characters long`,
  },
};
```


My hope is that this makes things like #8 and #21 a good bit easier 🤞 