### PR TITLE
Initial support for multiple inputs

### DIFF
--- a/demo-app/app/routes/index.tsx
+++ b/demo-app/app/routes/index.tsx
@@ -20,6 +20,7 @@ interface FormSchema {
     middleInitial: InputDefinition;
     lastName: InputDefinition;
     emailAddress: InputDefinition;
+    hobby: InputDefinition;
   };
   errorMessages: {
     tooShort: ErrorMessage;
@@ -62,6 +63,11 @@ let formDefinition: FormSchema = {
         uniqueEmail(attrValue, name, value) {
           return `The email address "${value}" is already in use!`;
         },
+      },
+    },
+    hobby: {
+      validationAttrs: {
+        required: true,
       },
     },
   },
@@ -268,6 +274,17 @@ export default function Index() {
             </p>
             <div className="demo-input">
               <EmailAddress />
+            </div>
+          </div>
+
+          <div className="demo-input-container">
+            <p className="demo-input-message">
+              Each of these hobby inputs has <code>required="true"</code>
+            </p>
+            <div className="demo-input">
+              <Field name="hobby" label="Hobby #1" index={0} />
+              <Field name="hobby" label="Hobby #2" index={1} />
+              <Field name="hobby" label="Hobby #3" index={2} />
             </div>
           </div>
 


### PR DESCRIPTION
### ⚠️ Breaking Change

First pass at support for multiple inputs

Main API changes:

* `serverFormInfo.submittedFormData` renamed to `serverFormInfo.submittedValues`
* `serverFormInfo.submittedValues` now has a value type of `string | string[]` and will be an array if multiple values are submitted for the given input name
* `serverFormInfo.inputs` now has a value type of `InputInfo | InputInfo[]` and will be an array if multiple values are submitted for the given input name
* `useValidatedInput` and `Field` now take an optional `index` prop that is required if it's a multiple-value input, so we can figure out which value/validation to refer to

```html
<Field name="hobby" label="Hobby #1" index={0} />
<Field name="hobby" label="Hobby #2" index={1} />
<Field name="hobby" label="Hobby #3" index={2} />
```

I'd love to figure out how to type `submittedValues` correctly as `string` for single-value inputs and `string[]` for multiple values inputs, but goin g to kick that to a new issue for now.  Might need to reach out to someone for help on the TS side there though 😂 

Closes #8