### PR TITLE
Dynamic Attrs

### DIFF
--- a/demo-app/app/routes/index.tsx
+++ b/demo-app/app/routes/index.tsx
@@ -21,6 +21,8 @@ interface FormSchema {
     lastName: InputDefinition;
     emailAddress: InputDefinition;
     hobby: InputDefinition;
+    low: InputDefinition;
+    high: InputDefinition;
   };
   errorMessages: {
     tooShort: ErrorMessage;
@@ -70,15 +72,23 @@ let formDefinition: FormSchema = {
         required: true,
       },
     },
+    low: {
+      validationAttrs: {
+        type: "number",
+        max: (fd) => (fd.get("high") ? Number(fd.get("high")) : undefined),
+      },
+    },
+    high: {
+      validationAttrs: {
+        type: "number",
+        min: (fd) => (fd.get("low") ? Number(fd.get("low")) : undefined),
+      },
+    },
   },
   errorMessages: {
     tooShort: (attrValue, name, value) =>
       `The ${name} field must be at least ${attrValue} characters long, but you have only entered ${value.length} characters`,
   },
-};
-
-type ActionData = {
-  serverFormInfo: ServerFormInfo<typeof formDefinition>;
 };
 
 export const action = async ({ request }: ActionArgs) => {
@@ -220,14 +230,19 @@ export default function Index() {
       <FormContextProvider
         value={{
           formDefinition,
-          // TODO: Can this case go away?  Seems to be coming from the
-          // serialization logic in the useActionData generic
           serverFormInfo: actionData?.serverFormInfo as ServerFormInfo<
             typeof formDefinition
           >,
         }}
       >
-        <Form method="post" autoComplete="off" ref={formRef}>
+        <Form
+          method="post"
+          autoComplete="off"
+          ref={formRef}
+          onChange={(e) => {
+            console.log("form onChange", e);
+          }}
+        >
           <div className="demo-input-container">
             <p className="demo-input-message">
               This first name input has{" "}
@@ -285,6 +300,17 @@ export default function Index() {
               <Field name="hobby" label="Hobby #1" index={0} />
               <Field name="hobby" label="Hobby #2" index={1} />
               <Field name="hobby" label="Hobby #3" index={2} />
+            </div>
+          </div>
+
+          <div className="demo-input-container">
+            <p className="demo-input-message">
+              These low/high inputs use dynamic <code>min</code>/
+              <code>max</code> attributes based on the value of the other input
+            </p>
+            <div className="demo-input">
+              <Field name="low" label="Low" />
+              <Field name="high" label="High" />
             </div>
           </div>
 

--- a/demo-app/app/routes/index.tsx
+++ b/demo-app/app/routes/index.tsx
@@ -9,7 +9,7 @@ import type {
 } from "remix-validity-state";
 import {
   Field,
-  FormContextProvider,
+  FormProvider,
   useValidatedInput,
   validateServerFormData,
 } from "remix-validity-state";
@@ -227,22 +227,14 @@ export default function Index() {
         .
       </p>
       <hr />
-      <FormContextProvider
-        value={{
-          formDefinition,
-          serverFormInfo: actionData?.serverFormInfo as ServerFormInfo<
-            typeof formDefinition
-          >,
-        }}
+      <FormProvider
+        formDefinition={formDefinition}
+        serverFormInfo={
+          actionData?.serverFormInfo as ServerFormInfo<typeof formDefinition>
+        }
+        formRef={formRef}
       >
-        <Form
-          method="post"
-          autoComplete="off"
-          ref={formRef}
-          onChange={(e) => {
-            console.log("form onChange", e);
-          }}
-        >
+        <Form method="post" autoComplete="off" ref={formRef}>
           <div className="demo-input-container">
             <p className="demo-input-message">
               This first name input has{" "}
@@ -316,7 +308,7 @@ export default function Index() {
 
           <button type="submit">Submit</button>
         </Form>
-      </FormContextProvider>
+      </FormProvider>
     </div>
   );
 }


### PR DESCRIPTION
### ⚠️ Breaking Change

Adds support for dynamic built-in validation attributes that are dependent on other form values.  You opt into this by providing a function as the value on your `validationAttrs` object.  The function receives one parameter which is the current `FormData` for the form.  You return a `string` from the function to set the attribute, or `null`/`undefined` to not render the attribute.

For example - we have 2 numeric inputs here, `low` and `high`.  If `low` has a value, then `high` sets it's `min` validation attribute to the value of `low` and vice versa.

```js
interface FormSchema {
  inputs: {
    low: InputDefinition;
    high: InputDefinition;
  };
}

let formDefinition: FormSchema = {
  inputs: {
    low: {
      validationAttrs: {
        type: "number",
        max: (fd) => (fd.get("high") ? Number(fd.get("high")) : undefined),
      },
    },
    high: {
      validationAttrs: {
        type: "number",
        min: (fd) => (fd.get("low") ? Number(fd.get("low")) : undefined),
      },
    },
  },
};
```

This is the first introduction of form-level awareness.  Thus far, everything happened at the individual input level via `useValidatedInput` so there was no way to force `high` to update if a change happened on `low`.  It would remain stale until the next time the user focused/changed high and forced a re-render.  To get around this, we introduce an internal `forceUpdate` concept inside of a new `<FormProvider>` component which replaces the old direct usage of `FormContext.Provider`.  This accepts a `formRef` and listened for a `change` event and updates the context.  this logic only applies if you have dynamic attributes in your form - and is skipped if all attribute values are static.

Closes #21