### PR TITLE
Add support for other controls (textarea, select, radio, checkbox)

### DIFF
--- a/demo-app/.eslintignore
+++ b/demo-app/.eslintignore
@@ -1,0 +1,2 @@
+build/
+public/build/

--- a/demo-app/app/routes/index.tsx
+++ b/demo-app/app/routes/index.tsx
@@ -13,7 +13,6 @@ import {
   Select,
   TextArea,
   useValidatedInput,
-  useValidatedTextArea,
   validateServerFormData,
 } from "remix-validity-state";
 
@@ -28,6 +27,8 @@ interface FormSchema {
     low: InputDefinition;
     high: InputDefinition;
     favoriteColor: InputDefinition;
+    skills: InputDefinition;
+    favoriteSkill: InputDefinition;
   };
   errorMessages: {
     tooShort: ErrorMessage;
@@ -100,6 +101,18 @@ let formDefinition: FormSchema = {
         required: true,
       },
     },
+    skills: {
+      validationAttrs: {
+        type: "checkbox",
+        required: true,
+      },
+    },
+    favoriteSkill: {
+      validationAttrs: {
+        type: "radio",
+        required: true,
+      },
+    },
   },
   errorMessages: {
     tooShort: (attrValue, name, value) =>
@@ -141,6 +154,73 @@ function EmailAddress() {
         </ul>
       ) : null}
     </div>
+  );
+}
+
+let skills = ["React", "Vue", "Preact", "Angular", "Svelte", "Solid", "Qwik"];
+
+function Skills() {
+  let [forceUpdate, setForceUpdate] = React.useState({});
+  let { info, getInputAttrs, getLabelAttrs, getErrorsAttrs } =
+    useValidatedInput<typeof formDefinition>({ name: "skills", forceUpdate });
+  // Since we'll share these attributes across all checkboxes we call these
+  // once here to avoid calling per-input.  And since we put the input inside
+  // the label we don't need the `for` attribute
+  let labelAttrs = getLabelAttrs({ htmlFor: undefined });
+  let inputAttrs = getInputAttrs();
+  return (
+    <fieldset onBlur={() => setForceUpdate({})}>
+      <legend>Pick a few skills:</legend>
+      {skills.map((s) => (
+        <label key={s} {...labelAttrs}>
+          {/* Make the id unique for this checkbox, based on value */}
+          <input
+            {...{ ...inputAttrs, id: `${inputAttrs.id}--${s.toLowerCase()}` }}
+          />
+          &nbsp;
+          {s}
+        </label>
+      ))}
+      {info.touched && info.errorMessages ? (
+        <ul {...getErrorsAttrs()}>
+          {Object.entries(info.errorMessages).map(([validation, msg]) => (
+            <li key={validation}>🆘 {msg}</li>
+          ))}
+        </ul>
+      ) : null}
+    </fieldset>
+  );
+}
+
+function FavoriteSkill() {
+  let { info, getInputAttrs, getLabelAttrs, getErrorsAttrs } =
+    useValidatedInput<typeof formDefinition>({ name: "favoriteSkill" });
+  // Since we'll share these attributes across all radios we call these
+  // once here to avoid calling per-input.  And since we put the input inside
+  // the label we don't need the `for` attribute
+  let labelAttrs = getLabelAttrs({ htmlFor: undefined });
+  let inputAttrs = getInputAttrs();
+  return (
+    <fieldset>
+      <legend>Pick a favorite skill:</legend>
+      {skills.map((s) => (
+        <label key={s} {...labelAttrs}>
+          {/* Make the id unique for this radio, based on value */}
+          <input
+            {...{ ...inputAttrs, id: `${inputAttrs.id}--${s.toLowerCase()}` }}
+          />
+          &nbsp;
+          {s}
+        </label>
+      ))}
+      {info.touched && info.errorMessages ? (
+        <ul {...getErrorsAttrs()}>
+          {Object.entries(info.errorMessages).map(([validation, msg]) => (
+            <li key={validation}>🆘 {msg}</li>
+          ))}
+        </ul>
+      ) : null}
+    </fieldset>
   );
 }
 
@@ -189,7 +269,7 @@ export default function Index() {
           width: 10rem;
         }
 
-        .rvs-input, .rvs-textarea, .rvs-select {
+        .rvs-input:not([type=checkbox]):not([type=radio]), .rvs-textarea, .rvs-select {
           display: inline-block;
           border: 1px solid lightgrey;
           padding: 0.5rem;
@@ -201,9 +281,7 @@ export default function Index() {
           border-color: red;
         }
 
-        .rvs-input.rvs-input--touched:not(.rvs-input--invalid):not(.rvs-input--validating),
-        .rvs-textarea.rvs-textarea--touched:not(.rvs-textarea--invalid):not(.rvs-textarea--validating),
-        .rvs-select.rvs-select--touched:not(.rvs-select--invalid):not(.rvs-select--validating) {
+        .rvs-input.rvs-input--touched:not(.rvs-input--invalid):not(.rvs-input--validating) {
             border-color: lightgreen;
         }
 
@@ -348,6 +426,26 @@ export default function Index() {
                 <option value="indigo">Indigo</option>
                 <option value="violet">Violet</option>
               </Select>
+            </div>
+          </div>
+
+          <div className="demo-input-container">
+            <p className="demo-input-message">
+              This set of checkboxes has <code>required="true"</code>
+              <br />
+            </p>
+            <div className="demo-input">
+              <Skills />
+            </div>
+          </div>
+
+          <div className="demo-input-container">
+            <p className="demo-input-message">
+              This set of radios has <code>required="true"</code>
+              <br />
+            </p>
+            <div className="demo-input">
+              <FavoriteSkill />
             </div>
           </div>
 

--- a/demo-app/app/routes/index.tsx
+++ b/demo-app/app/routes/index.tsx
@@ -1,11 +1,13 @@
-import { Form, useActionData } from "@remix-run/react";
 import type { ActionArgs } from "@remix-run/node";
 import { json, redirect } from "@remix-run/node";
+import { Form, useActionData } from "@remix-run/react";
 import * as React from "react";
 import type {
   ErrorMessage,
   InputDefinition,
+  SelectDefinition,
   ServerFormInfo,
+  TextAreaDefinition,
 } from "remix-validity-state";
 import {
   Field,
@@ -22,11 +24,11 @@ interface FormSchema {
     middleInitial: InputDefinition;
     lastName: InputDefinition;
     emailAddress: InputDefinition;
-    story: InputDefinition;
     hobby: InputDefinition;
     low: InputDefinition;
     high: InputDefinition;
-    favoriteColor: InputDefinition;
+    story: TextAreaDefinition;
+    favoriteColor: SelectDefinition;
     skills: InputDefinition;
     favoriteSkill: InputDefinition;
   };
@@ -73,12 +75,6 @@ let formDefinition: FormSchema = {
         },
       },
     },
-    story: {
-      validationAttrs: {
-        required: true,
-        minLength: 10,
-      },
-    },
     hobby: {
       validationAttrs: {
         required: true,
@@ -96,7 +92,15 @@ let formDefinition: FormSchema = {
         min: (fd) => (fd.get("low") ? Number(fd.get("low")) : undefined),
       },
     },
+    story: {
+      element: "textarea",
+      validationAttrs: {
+        required: true,
+        minLength: 10,
+      },
+    },
     favoriteColor: {
+      element: "select",
       validationAttrs: {
         required: true,
       },
@@ -133,6 +137,7 @@ export const action = async ({ request }: ActionArgs) => {
   if (!serverFormInfo.valid) {
     return json({ serverFormInfo });
   }
+
   return redirect("/");
 };
 
@@ -281,7 +286,9 @@ export default function Index() {
           border-color: red;
         }
 
-        .rvs-input.rvs-input--touched:not(.rvs-input--invalid):not(.rvs-input--validating) {
+        .rvs-input.rvs-input--touched:not(.rvs-input--invalid):not(.rvs-input--validating),
+        .rvs-textarea.rvs-textarea--touched:not(.rvs-textarea--invalid):not(.rvs-textarea--validating),
+        .rvs-select.rvs-select--touched:not(.rvs-select--invalid):not(.rvs-select--validating) {
             border-color: lightgreen;
         }
 
@@ -382,15 +389,6 @@ export default function Index() {
 
           <div className="demo-input-container">
             <p className="demo-input-message">
-              This story textarea is required with a minlength of 10
-            </p>
-            <div className="demo-input">
-              <TextArea name="story" label="Tell me a story:" />
-            </div>
-          </div>
-
-          <div className="demo-input-container">
-            <p className="demo-input-message">
               Each of these hobby inputs has <code>required="true"</code>
             </p>
             <div className="demo-input">
@@ -408,6 +406,16 @@ export default function Index() {
             <div className="demo-input">
               <Field<FormSchema> name="low" label="Low" />
               <Field<FormSchema> name="high" label="High" />
+            </div>
+          </div>
+
+          <div className="demo-input-container">
+            <p className="demo-input-message">
+              This story <code>textarea</code> has <code>required="true"</code>{" "}
+              and <code>minlength="10"</code>
+            </p>
+            <div className="demo-input">
+              <TextArea name="story" label="Tell me a story:" />
             </div>
           </div>
 

--- a/demo-app/app/routes/index.tsx
+++ b/demo-app/app/routes/index.tsx
@@ -11,6 +11,7 @@ import {
   Field,
   FormProvider,
   useValidatedInput,
+  useValidatedTextArea,
   validateServerFormData,
 } from "remix-validity-state";
 
@@ -20,6 +21,7 @@ interface FormSchema {
     middleInitial: InputDefinition;
     lastName: InputDefinition;
     emailAddress: InputDefinition;
+    story: InputDefinition;
     hobby: InputDefinition;
     low: InputDefinition;
     high: InputDefinition;
@@ -65,6 +67,12 @@ let formDefinition: FormSchema = {
         uniqueEmail(attrValue, name, value) {
           return `The email address "${value}" is already in use!`;
         },
+      },
+    },
+    story: {
+      validationAttrs: {
+        required: true,
+        minLength: 10,
       },
     },
     hobby: {
@@ -117,6 +125,27 @@ function EmailAddress() {
       <label {...getLabelAttrs()}>Email Address*</label>
       <br />
       <input {...getInputAttrs()} />
+      {info.touched && info.errorMessages ? (
+        <ul {...getErrorsAttrs()}>
+          {Object.entries(info.errorMessages).map(([validation, msg]) => (
+            <li key={validation}>🆘 {msg}</li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+// This is a more complex example of skipping <Field/> in favor of manual
+// DOM construction
+function Story() {
+  let { info, getTextAreaAttrs, getLabelAttrs, getErrorsAttrs } =
+    useValidatedTextArea<typeof formDefinition>({ name: "story" });
+  return (
+    <div>
+      <label {...getLabelAttrs()}>Story*</label>
+      <br />
+      <textarea {...getTextAreaAttrs({ rows: 10, cols: 100 })} />
       {info.touched && info.errorMessages ? (
         <ul {...getErrorsAttrs()}>
           {Object.entries(info.errorMessages).map(([validation, msg]) => (
@@ -281,6 +310,15 @@ export default function Index() {
             </p>
             <div className="demo-input">
               <EmailAddress />
+            </div>
+          </div>
+
+          <div className="demo-input-container">
+            <p className="demo-input-message">
+              This story textarea is required with a minlength of 10
+            </p>
+            <div className="demo-input">
+              <Story />
             </div>
           </div>
 

--- a/demo-app/app/routes/index.tsx
+++ b/demo-app/app/routes/index.tsx
@@ -10,6 +10,8 @@ import type {
 import {
   Field,
   FormProvider,
+  Select,
+  TextArea,
   useValidatedInput,
   useValidatedTextArea,
   validateServerFormData,
@@ -25,6 +27,7 @@ interface FormSchema {
     hobby: InputDefinition;
     low: InputDefinition;
     high: InputDefinition;
+    favoriteColor: InputDefinition;
   };
   errorMessages: {
     tooShort: ErrorMessage;
@@ -92,6 +95,11 @@ let formDefinition: FormSchema = {
         min: (fd) => (fd.get("low") ? Number(fd.get("low")) : undefined),
       },
     },
+    favoriteColor: {
+      validationAttrs: {
+        required: true,
+      },
+    },
   },
   errorMessages: {
     tooShort: (attrValue, name, value) =>
@@ -125,27 +133,6 @@ function EmailAddress() {
       <label {...getLabelAttrs()}>Email Address*</label>
       <br />
       <input {...getInputAttrs()} />
-      {info.touched && info.errorMessages ? (
-        <ul {...getErrorsAttrs()}>
-          {Object.entries(info.errorMessages).map(([validation, msg]) => (
-            <li key={validation}>🆘 {msg}</li>
-          ))}
-        </ul>
-      ) : null}
-    </div>
-  );
-}
-
-// This is a more complex example of skipping <Field/> in favor of manual
-// DOM construction
-function Story() {
-  let { info, getTextAreaAttrs, getLabelAttrs, getErrorsAttrs } =
-    useValidatedTextArea<typeof formDefinition>({ name: "story" });
-  return (
-    <div>
-      <label {...getLabelAttrs()}>Story*</label>
-      <br />
-      <textarea {...getTextAreaAttrs({ rows: 10, cols: 100 })} />
       {info.touched && info.errorMessages ? (
         <ul {...getErrorsAttrs()}>
           {Object.entries(info.errorMessages).map(([validation, msg]) => (
@@ -202,7 +189,7 @@ export default function Index() {
           width: 10rem;
         }
 
-        .rvs-input {
+        .rvs-input, .rvs-textarea, .rvs-select {
           display: inline-block;
           border: 1px solid lightgrey;
           padding: 0.5rem;
@@ -210,12 +197,14 @@ export default function Index() {
           width: calc(100% - 1rem);
         }
 
-        .rvs-input--invalid {
+        .rvs-input--invalid, .rvs-textarea--invalid, .rvs-select--invalid {
           border-color: red;
         }
 
-        .rvs-input.rvs-input--touched:not(.rvs-input--invalid):not(.rvs-input--validating) {
-          border-color: lightgreen;
+        .rvs-input.rvs-input--touched:not(.rvs-input--invalid):not(.rvs-input--validating),
+        .rvs-textarea.rvs-textarea--touched:not(.rvs-textarea--invalid):not(.rvs-textarea--validating),
+        .rvs-select.rvs-select--touched:not(.rvs-select--invalid):not(.rvs-select--validating) {
+            border-color: lightgreen;
         }
 
         .rvs-validating {
@@ -270,7 +259,7 @@ export default function Index() {
               <code>required="true" minLength="5" pattern="^[a-zA-Z]+$"</code>
             </p>
             <div className="demo-input">
-              <Field name="firstName" label="First Name" />
+              <Field<FormSchema> name="firstName" label="First Name" />
             </div>
           </div>
 
@@ -282,7 +271,7 @@ export default function Index() {
               </code>
             </p>
             <div className="demo-input">
-              <Field name="middleInitial" label="Middle Initial" />
+              <Field<FormSchema> name="middleInitial" label="Middle Initial" />
             </div>
           </div>
 
@@ -292,7 +281,7 @@ export default function Index() {
               <code>required="true" minLength="5" pattern="^[a-zA-Z]+$"</code>
             </p>
             <div className="demo-input">
-              <Field name="lastName" label="Last Name" />
+              <Field<FormSchema> name="lastName" label="Last Name" />
             </div>
           </div>
 
@@ -318,7 +307,7 @@ export default function Index() {
               This story textarea is required with a minlength of 10
             </p>
             <div className="demo-input">
-              <Story />
+              <TextArea name="story" label="Tell me a story:" />
             </div>
           </div>
 
@@ -327,9 +316,9 @@ export default function Index() {
               Each of these hobby inputs has <code>required="true"</code>
             </p>
             <div className="demo-input">
-              <Field name="hobby" label="Hobby #1" index={0} />
-              <Field name="hobby" label="Hobby #2" index={1} />
-              <Field name="hobby" label="Hobby #3" index={2} />
+              <Field<FormSchema> name="hobby" label="Hobby #1" index={0} />
+              <Field<FormSchema> name="hobby" label="Hobby #2" index={1} />
+              <Field<FormSchema> name="hobby" label="Hobby #3" index={2} />
             </div>
           </div>
 
@@ -339,8 +328,26 @@ export default function Index() {
               <code>max</code> attributes based on the value of the other input
             </p>
             <div className="demo-input">
-              <Field name="low" label="Low" />
-              <Field name="high" label="High" />
+              <Field<FormSchema> name="low" label="Low" />
+              <Field<FormSchema> name="high" label="High" />
+            </div>
+          </div>
+
+          <div className="demo-input-container">
+            <p className="demo-input-message">
+              This select input has <code>required="true"</code>
+            </p>
+            <div className="demo-input">
+              <Select<FormSchema> name="favoriteColor" label="Favorite Color?">
+                <option value="" />
+                <option value="red">Red</option>
+                <option value="orange">Orange</option>
+                <option value="yellow">Yellow</option>
+                <option value="green">Green</option>
+                <option value="blue">Blue</option>
+                <option value="indigo">Indigo</option>
+                <option value="violet">Violet</option>
+              </Select>
             </div>
           </div>
 

--- a/demo-app/app/routes/index.tsx
+++ b/demo-app/app/routes/index.tsx
@@ -10,7 +10,7 @@ import type {
   TextAreaDefinition,
 } from "remix-validity-state";
 import {
-  Field,
+  Input,
   FormProvider,
   Select,
   TextArea,
@@ -344,7 +344,7 @@ export default function Index() {
               <code>required="true" minLength="5" pattern="^[a-zA-Z]+$"</code>
             </p>
             <div className="demo-input">
-              <Field<FormSchema> name="firstName" label="First Name" />
+              <Input<FormSchema> name="firstName" label="First Name" />
             </div>
           </div>
 
@@ -356,7 +356,7 @@ export default function Index() {
               </code>
             </p>
             <div className="demo-input">
-              <Field<FormSchema> name="middleInitial" label="Middle Initial" />
+              <Input<FormSchema> name="middleInitial" label="Middle Initial" />
             </div>
           </div>
 
@@ -366,7 +366,7 @@ export default function Index() {
               <code>required="true" minLength="5" pattern="^[a-zA-Z]+$"</code>
             </p>
             <div className="demo-input">
-              <Field<FormSchema> name="lastName" label="Last Name" />
+              <Input<FormSchema> name="lastName" label="Last Name" />
             </div>
           </div>
 
@@ -392,9 +392,9 @@ export default function Index() {
               Each of these hobby inputs has <code>required="true"</code>
             </p>
             <div className="demo-input">
-              <Field<FormSchema> name="hobby" label="Hobby #1" index={0} />
-              <Field<FormSchema> name="hobby" label="Hobby #2" index={1} />
-              <Field<FormSchema> name="hobby" label="Hobby #3" index={2} />
+              <Input<FormSchema> name="hobby" label="Hobby #1" index={0} />
+              <Input<FormSchema> name="hobby" label="Hobby #2" index={1} />
+              <Input<FormSchema> name="hobby" label="Hobby #3" index={2} />
             </div>
           </div>
 
@@ -404,8 +404,8 @@ export default function Index() {
               <code>max</code> attributes based on the value of the other input
             </p>
             <div className="demo-input">
-              <Field<FormSchema> name="low" label="Low" />
-              <Field<FormSchema> name="high" label="High" />
+              <Input<FormSchema> name="low" label="Low" />
+              <Input<FormSchema> name="high" label="High" />
             </div>
           </div>
 


### PR DESCRIPTION
Took a quick first stab at textarea support which oughta be closest in behavior to `<input type="text">`.  Most of the internals can be shared verbatim which is great.  But the inferred typings get really gnarly to try to support an API such as `useValidatedInput({ controlType: 'textarea', name: 'story' })` since sometimes we need the string value `input` or `textarea` for use with `React.ComponentPropsWithoutRef` and other times we need `HTMLInputElement` or `HTMLTextAreaElement` for `React.Ref` and `React.useRef` and trying to infer all that was proving ... difficult :).

So for this first pass I was able to share most of the logic but I chose to expose separate public APIs for user-land (bikeshedding still needed)

* [x] `useValidatedInput`/`Field` - handle `<input>` except for radios/checkboxes
* [x] `useValidatedTextArea`/`TextArea` - handle `<textarea>`
* [x] `useValidatedSelect`/`Select` - handle `<select>`
* [ ] ~`useValidatedRadioInput`/`Radio` - handle `<input type="radio">`~
* [ ] ~`useValidatedCheckboxInput`/`Checkbox` - handle `<input type="checkbox">`~
* [ ] ~Consider `<Fieldset>` or similar abstraction for radio/checkbox~
* [x] Rename `Field` to `Input` for consistency?

For the time being, I think we can stick with `getValidatedInput` for radio/checkboxes.  `<Field>` doesn't really work for multi-radio/checkbox inputs, so it works best with the manual hook invocation.  For the time being holding off on a fieldset abstraction since it can be manually accomplished

Closes #15 