### PR TITLE
make serverFormInfo optional in FormProvider

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1165,7 +1165,7 @@ export interface FormProviderProps<
   T extends FormDefinition
 > extends React.PropsWithChildren<{
     formDefinition: T;
-    serverFormInfo: ServerFormInfo<T>;
+    serverFormInfo?: ServerFormInfo<T>;
     formRef?: React.RefObject<HTMLFormElement>;
   }> {}
 


### PR DESCRIPTION
When you have:

```
<FormProvider
  serverFormInfo={actionData?.serverFormInfo}
  ...
>
...
```

`actionData` is undefined when you haven't submitted. Therefore this gives a type error unless you cast or assert non-nullish with `!`. Just making the `serverFormInfo` prop optional fixes this.